### PR TITLE
Fix memory flag on qemu-system-arm documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ sudo mount -v -o offset="$OFFSET" -t ext4 "$IMAGE_FILE" /mnt/printnanny
 qemu-system-arm \
 -kernel ~/projects/qemu-rpi-kernel/kernel-qemu-5.4.51-buster \
 -cpu arm64 \
--2048m \
+-m 2048m \
 -serial stdio \
 -redir tcp:8022:22 \
 -hda "$IMAGE_FILE" \


### PR DESCRIPTION
I believe qemu-system-arm requires an -m flag to set memory, though this may be due to building with a different version. I'm seeing this on qemu 6.x.