### PR TITLE
Document the dependency on qemu-rpi-kernel repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ sudo mount -v -o offset="$OFFSET" -t ext4 "$IMAGE_FILE" /mnt/printnanny
 4. Emulate with QEMU
 
 ```
+pushd ~/projects && \
+  git clone https://github.com/dhruvvyas90/qemu-rpi-kernel && \
+  popd
+
 qemu-system-arm \
 -kernel ~/projects/qemu-rpi-kernel/kernel-qemu-5.4.51-buster \
 -cpu arm64 \


### PR DESCRIPTION
The documentation seems to reference the https://github.com/dhruvvyas90/qemu-rpi-kernel repo and expects it to appear under the ~/projects folder, but it doesn't explicitly say to clone it, so this change adds a git clone operation to the instructions to ensure that the repo is present.